### PR TITLE
fix(auth): add token refresh mutex to prevent race condition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,10 +238,26 @@ conn.close()
 
 ## Claude Code Integration
 
+### Git Workflow
+
+**CRITICAL: NEVER push directly to `main` branch.**
+
+1. Create a feature branch for changes (e.g., `fix/auth-token-refresh`)
+2. Commit changes to the feature branch
+3. Push the feature branch to origin
+4. Create a Pull Request using `gh pr create`
+5. **STOP** - User will review and merge the PR themselves
+
+**Branch Naming:**
+- `fix/` - Bug fixes
+- `feat/` - New features
+- `refactor/` - Code refactoring
+- `docs/` - Documentation updates
+
 ### Deployment Workflow
-1. Make code changes
-2. Commit and push to GitHub
-3. **DO NOT deploy** - User handles deployment manually
+1. Make code changes on a feature branch
+2. Create PR for user review
+3. **DO NOT merge or deploy** - User handles merging and deployment manually
 
 ### Slash Commands
 | Command | Purpose |

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 
 // In production, use relative URLs (empty VITE_API_URL) so nginx can proxy requests
 // In development, use explicit localhost URL
@@ -10,6 +10,24 @@ export const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+// Token refresh mutex to prevent race conditions
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (token: string) => void;
+  reject: (error: unknown) => void;
+}> = [];
+
+const processQueue = (error: unknown, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token!);
+    }
+  });
+  failedQueue = [];
+};
 
 // Request interceptor for adding auth token
 apiClient.interceptors.request.use(
@@ -25,14 +43,31 @@ apiClient.interceptors.request.use(
   }
 );
 
-// Response interceptor for handling token refresh
+// Response interceptor for handling token refresh with mutex
 apiClient.interceptors.response.use(
   (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+    if (!originalRequest) {
+      return Promise.reject(error);
+    }
 
     if (error.response?.status === 401 && !originalRequest._retry) {
+      // If already refreshing, queue this request
+      if (isRefreshing) {
+        return new Promise<string>((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        }).then((token) => {
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+          return apiClient(originalRequest);
+        }).catch((err) => {
+          return Promise.reject(err);
+        });
+      }
+
       originalRequest._retry = true;
+      isRefreshing = true;
 
       try {
         const refreshToken = localStorage.getItem('refresh_token');
@@ -44,15 +79,26 @@ apiClient.interceptors.response.use(
 
           const { access_token } = response.data;
           localStorage.setItem('access_token', access_token);
-          originalRequest.headers.Authorization = `Bearer ${access_token}`;
 
+          // Process queued requests with new token
+          processQueue(null, access_token);
+
+          originalRequest.headers.Authorization = `Bearer ${access_token}`;
           return apiClient(originalRequest);
+        } else {
+          // No refresh token available
+          processQueue(new Error('No refresh token'), null);
+          window.location.href = '/login';
+          return Promise.reject(error);
         }
       } catch (refreshError) {
+        processQueue(refreshError, null);
         localStorage.removeItem('access_token');
         localStorage.removeItem('refresh_token');
         window.location.href = '/login';
         return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
       }
     }
 


### PR DESCRIPTION
## Summary
- Added token refresh mutex to prevent race condition when multiple API requests receive 401 errors simultaneously
- When access tokens expire during long-running jobs, multiple requests would all try to refresh simultaneously causing some to fail with "Missing authentication credentials"
- Updated CLAUDE.md with git workflow rules (never push to main, always use PRs)

## Changes
1. **`frontend/src/utils/api.ts`** - Added mutex pattern for token refresh:
   - Queues requests that arrive while refresh is in progress
   - Ensures only ONE refresh request is made to the server
   - Retries all queued requests with the new token once refresh completes

2. **`CLAUDE.md`** - Added git workflow documentation:
   - Never push directly to main
   - Always create feature branches
   - Create PRs for user review

## Test plan
- [ ] Start a long-running ETL job (>15 minutes of data)
- [ ] Wait for token expiration (check Network tab for 401 responses)
- [ ] Verify only ONE refresh request is made (not multiple)
- [ ] Verify subsequent API calls succeed with new token
- [ ] Verify no "Missing authentication credentials" errors appear

🤖 Generated with [Claude Code](https://claude.ai/code)